### PR TITLE
Add flutter lints, convert `IntroScreen` to stateful

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,29 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at
+  # https://dart-lang.github.io/linter/lints/index.html.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    avoid_print: false
+    prefer_single_quotes: true
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:nice_intro/intro_screen.dart';
 import 'package:nice_intro/intro_screens.dart';
 
-void main() => runApp(MyApp());
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -12,13 +14,15 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: MyHomePage(),
+      home: const MyHomePage(),
       debugShowCheckedModeBanner: false,
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
+  const MyHomePage({Key? key}) : super(key: key);
+
   @override
   MyHomePageState createState() {
     return MyHomePageState();
@@ -31,7 +35,7 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
     var screens = IntroScreens(
       onDone: () => Navigator.of(context).push(
         MaterialPageRoute(
-          builder: (context) => NextPage(),
+          builder: (context) => const NextPage(),
         ),
       ),
       onSkip: () => print('Skipping the intro slides'),
@@ -39,7 +43,7 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
       activeDotColor: Colors.white,
       footerRadius: 18.0,
 //      indicatorType: IndicatorType.CIRCLE,
-      slides: [
+      slides: const [
         IntroScreen(
           title: 'Search',
           imageAsset: 'assets/img/1.png',
@@ -56,7 +60,7 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
           title: 'Social',
           headerBgColor: Colors.white,
           imageAsset: 'assets/img/3.png',
-          description: "Keep talking with your mates",
+          description: 'Keep talking with your mates',
         ),
       ],
     );
@@ -68,6 +72,8 @@ class MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
 }
 
 class NextPage extends StatefulWidget {
+  const NextPage({Key? key}) : super(key: key);
+
   @override
   _NextPageState createState() => _NextPageState();
 }

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class IntroScreen extends StatelessWidget {
+class IntroScreen extends StatefulWidget {
   ///This is a builder for an intro screen
   ///
   ///
@@ -33,9 +33,7 @@ class IntroScreen extends StatelessWidget {
   ///[Widget]
   final Widget? header;
 
-  int? _pageIndex;
-
-  IntroScreen({
+  const IntroScreen({
     required String this.title,
     this.headerPadding = const EdgeInsets.all(12),
     required String this.description,
@@ -43,38 +41,46 @@ class IntroScreen extends StatelessWidget {
     this.headerBgColor = Colors.white,
     this.textStyle,
     this.imageAsset,
-  });
+    Key? key,
+  }) : super(key: key);
 
-  set index(val) => this._pageIndex = val;
+  @override
+  State<IntroScreen> createState() => _IntroScreenState();
+}
+
+class _IntroScreenState extends State<IntroScreen> {
+  int? _pageIndex;
+
+  set index(val) => _pageIndex = val;
 
   @override
   Widget build(BuildContext context) {
     var screenSize = MediaQuery.of(context).size;
-    return Container(
+    return SizedBox(
       width: double.infinity,
       height: screenSize.height,
       child: Column(
         children: <Widget>[
           Container(
             height: screenSize.height * .666,
-            padding: headerPadding,
+            padding: widget.headerPadding,
             decoration: BoxDecoration(
-              color: headerBgColor,
+              color: widget.headerBgColor,
             ),
             child: Center(
-              child: imageAsset != null
+              child: widget.imageAsset != null
                   ? Image.asset(
-                      imageAsset!,
+                      widget.imageAsset!,
                       fit: BoxFit.cover,
                       width: double.infinity,
                       height: screenSize.height * .3,
                     )
-                  : this.header ??
-                      Container(
-                        child: Text(
-                          "${this._pageIndex ?? 1}",
-                          style: TextStyle(
-                              fontSize: 300, fontWeight: FontWeight.w900),
+                  : widget.header ??
+                      Text(
+                        '${_pageIndex ?? 1}',
+                        style: const TextStyle(
+                          fontSize: 300,
+                          fontWeight: FontWeight.w900,
                         ),
                       ),
             ),

--- a/lib/intro_screens.dart
+++ b/lib/intro_screens.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
@@ -101,8 +103,8 @@ class IntroScreens extends StatefulWidget {
     this.viewPortFraction = 1.0,
     this.textColor = Colors.white,
     this.footerPadding = const EdgeInsets.all(24),
-    this.footerBgColor = const Color(0xff51adf6),
-  }) : assert(slides.length > 0);
+    this.footerBgColor = const Color(0xff51adf6),Key?key,
+  }) : assert(slides.length > 0), super(key:key);
 }
 
 class _IntroScreensState extends State<IntroScreens>
@@ -126,7 +128,7 @@ class _IntroScreensState extends State<IntroScreens>
 
     currentScreen = widget.slides[0];
     animationController =
-        AnimationController(duration: Duration(milliseconds: 500), vsync: this);
+        AnimationController(duration: const Duration(milliseconds: 500), vsync: this);
   }
 
   TextStyle get textStyle =>
@@ -135,7 +137,7 @@ class _IntroScreensState extends State<IntroScreens>
           fontSize: 18, color: Colors.white, fontWeight: FontWeight.normal);
 
   Widget get next =>
-      this.widget.nextWidget ??
+      widget.nextWidget ??
       Icon(
         Icons.arrow_forward,
         size: 28,
@@ -143,7 +145,7 @@ class _IntroScreensState extends State<IntroScreens>
       );
 
   Widget get done =>
-      this.widget.doneWidget ??
+      widget.doneWidget ??
       Icon(
         Icons.check,
         size: 28,
@@ -157,7 +159,7 @@ class _IntroScreensState extends State<IntroScreens>
     super.dispose();
   }
 
-  bool get existGradientColors => widget.footerGradients.length > 0;
+  bool get existGradientColors => widget.footerGradients.isNotEmpty;
 
   LinearGradient get gradients => existGradientColors
       ? LinearGradient(
@@ -257,7 +259,7 @@ class _IntroScreensState extends State<IntroScreens>
                   alignment: Alignment.topCenter,
                   child: Column(
                     children: <Widget>[
-                      SizedBox(
+                      const SizedBox(
                         height: 24,
                       ),
                       Text(
@@ -272,7 +274,7 @@ class _IntroScreensState extends State<IntroScreens>
                         ),
                         textAlign: TextAlign.center,
                       ),
-                      SizedBox(
+                      const SizedBox(
                         height: 24,
                       ),
                       Text(
@@ -296,7 +298,7 @@ class _IntroScreensState extends State<IntroScreens>
               child: Padding(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 20.0, vertical: 4.0),
-                child: Container(
+                child: SizedBox(
                   width: double.infinity,
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -319,7 +321,7 @@ class _IntroScreensState extends State<IntroScreens>
                         ),
                       ),
                       Expanded(
-                        child: Container(
+                        child: SizedBox(
                           width: 160,
                           child: PageIndicator(
                             type: widget.indicatorType,
@@ -331,7 +333,7 @@ class _IntroScreensState extends State<IntroScreens>
                             onTap: () {
                               _controller!.animateTo(
                                 _controller!.page!,
-                                duration: Duration(
+                                duration: const Duration(
                                   milliseconds: 400,
                                 ),
                                 curve: Curves.fastOutSlowIn,
@@ -356,7 +358,7 @@ class _IntroScreensState extends State<IntroScreens>
                                 borderRadius: BorderRadius.circular(100),
                                 child: next,
                                 onTap: () => _controller!.nextPage(
-                                    duration: Duration(milliseconds: 800),
+                                    duration: const Duration(milliseconds: 800),
                                     curve: Curves.fastOutSlowIn),
                               ),
                       )

--- a/lib/page_indicator.dart
+++ b/lib/page_indicator.dart
@@ -12,20 +12,20 @@ class PageIndicator extends StatelessWidget {
   final IndicatorType? type;
   final VoidCallback? onTap;
 
-  PageIndicator({
+  const PageIndicator({
     this.currentIndex,
     this.pageCount,
     this.activeDotColor,
     this.onTap,
     this.inactiveDotColor,
-    this.type,
-  });
+    this.type,Key?key,
+  }):super(key:key);
 
   _indicator(bool isActive) {
     return GestureDetector(
-      onTap: this.onTap,
+      onTap: onTap,
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 6.0),
+        padding: const EdgeInsets.symmetric(horizontal: 6.0),
         child: buildIndicatorShape(type, isActive),
       ),
     );
@@ -42,7 +42,7 @@ class PageIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new Row(
+    return  Row(
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: _buildPageIndicators(),
@@ -64,7 +64,7 @@ class PageIndicator extends StatelessWidget {
           width: type == IndicatorType.CIRCLE || type == IndicatorType.DIAMOND
               ? 8.0
               : 24.0,
-          duration: Duration(milliseconds: 300),
+          duration: const Duration(milliseconds: 300),
           decoration: decoration(isActive, type),
         ),
       ),
@@ -85,7 +85,7 @@ class PageIndicator extends StatelessWidget {
           color: Colors.black.withOpacity(
             .02,
           ),
-          offset: Offset(0.0, 2.0),
+          offset: const Offset(0.0, 2.0),
           blurRadius: 2.0,
         )
       ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -76,6 +76,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct main"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -102,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_lints: ^1.0.4
   google_fonts: ^2.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Hey @Ethiel97,

I added `flutter_lints` and fixed up most of the resulting lint warnings. However, there are a couple still outstanding.

The more concerning issue is with `IntroScreen`. The way this application is currently built, you have a `StatelessWidget` with state, being modified by another widget. Due to implementation reasons this will appear to work, however having mutable state in a StatelessWidget is a solid no as it will break.

I'd suggest re-working this app with some state management to pull out this magic and make the rendering logic less intertwined with the business logic.